### PR TITLE
Fix compatibility with Windows

### DIFF
--- a/httpstat.php
+++ b/httpstat.php
@@ -248,8 +248,8 @@ function main()
     $cmdArr = array(
         $curlBin,
         '-w', "'{$curlFormat}'",
-        '-D', "'{$headerFName}'",
-        '-o', "'{$bodyFName}'",
+        '-D', "\"{$headerFName}\"",
+        '-o', "\"{$bodyFName}\"",
         '-s', '-S'
     );
 

--- a/httpstat.php
+++ b/httpstat.php
@@ -36,15 +36,15 @@ $ENV_DEBUG = new Env('{prefix}_DEBUG');
 
 
 $curlFormat = '{' .
-    '"time_namelookup": %{time_namelookup},' .
-    '"time_connect": %{time_connect},' .
-    '"time_appconnect": %{time_appconnect},' .
-    '"time_pretransfer": %{time_pretransfer},' .
-    '"time_redirect": %{time_redirect},' .
-    '"time_starttransfer": %{time_starttransfer},' .
-    '"time_total": %{time_total},' .
-    '"speed_download": %{speed_download},' .
-    '"speed_upload": %{speed_upload}' .
+    '\"time_namelookup\": %{time_namelookup},' .
+    '\"time_connect\": %{time_connect},' .
+    '\"time_appconnect\": %{time_appconnect},' .
+    '\"time_pretransfer\": %{time_pretransfer},' .
+    '\"time_redirect\": %{time_redirect},' .
+    '\"time_starttransfer\": %{time_starttransfer},' .
+    '\"time_total\": %{time_total},' .
+    '\"speed_download\": %{speed_download},' .
+    '\"speed_upload\": %{speed_upload}' .
     '}';
 
 
@@ -247,7 +247,7 @@ function main()
 
     $cmdArr = array(
         $curlBin,
-        '-w', "'{$curlFormat}'",
+        '-w', "\"{$curlFormat}\"",
         '-D', "\"{$headerFName}\"",
         '-o', "\"{$bodyFName}\"",
         '-s', '-S'
@@ -262,13 +262,16 @@ function main()
 
     $p = proc_open($cmd,
         array(
-            array("pipe", "r"),
-            array("pipe", "w"),
-            array("pipe", "w")
+            0 => array("pipe", "r"),
+            1 => array("pipe", "w"),
+            2 => array("pipe", "w")
         ),
         $pipes,
         sys_get_temp_dir(),
-        $cmdEnv);
+        null,//$cmdEnv,
+        [
+            //'bypass_shell' => true,
+    ]);
 
     $out = stream_get_contents($pipes[1]);
     $err = stream_get_contents($pipes[2]);

--- a/httpstat.php
+++ b/httpstat.php
@@ -68,8 +68,7 @@ $httpTemplate = "  DNS Lookup   TCP Connection   Server Processing   Content Tra
 ";
 
 
-$ISATTY = posix_isatty(STDOUT);
-
+$ISATTY = function_exists('posix_isatty') ? posix_isatty(STDOUT) : false;
 
 function makeColor($code)
 {
@@ -141,7 +140,7 @@ Options:
                 which are already used internally.
   -h --help     show this screen.
   --version     show version.
-  
+
 Environments:
   HTTPSTAT_SHOW_BODY    Set to `true` to show resposne body in the output,
                         note that body length is limited to 1023 bytes, will be

--- a/httpstat.php
+++ b/httpstat.php
@@ -68,7 +68,7 @@ $httpTemplate = "  DNS Lookup   TCP Connection   Server Processing   Content Tra
 ";
 
 
-$ISATTY = function_exists('posix_isatty') ? posix_isatty(STDOUT) : false;
+$ISATTY = function_exists('posix_isatty') ? posix_isatty(STDOUT) : true;
 
 function makeColor($code)
 {

--- a/httpstat.php
+++ b/httpstat.php
@@ -236,8 +236,14 @@ function main()
     fclose($headerF);
 
     // run cmd
-    $cmdEnv = $_ENV;
-    $cmdEnv['LC_ALL'] = 'C';
+    if (strcasecmp(substr(PHP_OS, 0, 3), 'WIN') != 0) {
+        // unix like systems
+        $cmdEnv = $_ENV;
+        $cmdEnv['LC_ALL'] = 'C';
+    }
+    else
+        // windows
+        $cmdEnv = null;
 
     $cmdArr = array(
         $curlBin,


### PR DESCRIPTION
Solves all Windows related issues I could find (#1), without breaking functionality in linux based systems.
Works in both classic `cmd.exe` and `mintty`.